### PR TITLE
First crack at rank restriction

### DIFF
--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -2,7 +2,7 @@
 
 local restrictedFunctions, rankRestrictedFunctions = include "sv_restricted_propcore_functions.lua"
 local function restrictPropCoreFunctions()
-    for _, signature in pairs( RESTRICTED_FUNCTIONS ) do
+    for _, signature in pairs( restrictedFunctions ) do
         local oldFunc = wire_expression2_funcs[signature][3]
         wire_expression2_funcs[signature][3] = function( self, ... )
             local playerGroup       = self.player:GetUserGroup()

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -16,7 +16,7 @@ local function restrictPropCoreFunctions()
             local restrictions      = groupRestrictions[signature]
 
             -- No restriction for this rank
-            if not restrictions then return oldFunc( self, ... )
+            if not restrictions then return oldFunc( self, ... ) end
 
             -- No access at all
             if restrictions.pvp and restrictions.build then

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -1,13 +1,7 @@
 -- Restricts PropCore functions based on rank
-include("sv_restricted_propcore_functions.lua")
 
+local restrictedFunctions, rankRestrictedFunctions = require "sv_restricted_propcore_functions"
 local function restrictPropCoreFunctions()
-    local rankRestrictedFunctions = {
-        'admin':   ADMIN_RESTRICTED_FUNCTIONS,
-        'regular': REGULAR_RESTRICTED_FUNCTIONS,
-        'user':    USER_RESTRICTED_FUNCTIONS
-    }
-
     for _, signature in pairs( RESTRICTED_FUNCTIONS ) do
         local oldFunc = wire_expression2_funcs[signature][3]
         wire_expression2_funcs[signature][3] = function( self, ... )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -8,9 +8,6 @@ local function restrictPropCoreFunctions()
             local playerGroup       = self.player:GetUserGroup()
             local groupRestrictions = rankRestrictedFunctions[playerGroup] or rankRestrictedFunctions['user']
             local restrictions      = groupRestrictions[signature]
-
-            if ( disallowedRanks[self.player:GetUserGroup()] == nil ) then
-                local isInBuildMode = self.player:GetNWBool("CFC_PvP_Mode", false) == false
         
             -- No restriction for this rank
             if not restrictions then return oldFunc( self, ... ) end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -1,6 +1,6 @@
 -- Restricts PropCore functions based on rank
 
-local restrictedFunctions, rankRestrictedFunctions = require "sv_restricted_propcore_functions"
+local restrictedFunctions, rankRestrictedFunctions = include "sv_restricted_propcore_functions.lua"
 local function restrictPropCoreFunctions()
     for _, signature in pairs( RESTRICTED_FUNCTIONS ) do
         local oldFunc = wire_expression2_funcs[signature][3]

--- a/lua/autorun/server/sv_restricted_propcore_functions.lua
+++ b/lua/autorun/server/sv_restricted_propcore_functions.lua
@@ -1,6 +1,6 @@
 -- Restricted Propcore Functions
 ---------------------------------------------------------------------------------------
-RESTRICTED_FUNCTIONS = {
+local RESTRICTED_FUNCTIONS = {
   'propSpawn(sn)',
   'propSpawn(en)',
   'propSpawn(svn)',
@@ -20,10 +20,10 @@ RESTRICTED_FUNCTIONS = {
 -- Rank Restriction Tables
 ---------------------------------------------------------------------------------------
 -- Admin rank restricted functions
-ADMIN_RESTRICTED_FUNCTIONS = {}
+local ADMIN_RESTRICTED_FUNCTIONS = {}
 
 -- Regular rank restricted functions
-REGULAR_RESTRICTED_FUNCTIONS = ADMIN_RESTRICTED_FUNCTIONS
+local REGULAR_RESTRICTED_FUNCTIONS = ADMIN_RESTRICTED_FUNCTIONS
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(sn)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(en)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(svn)']          = {build = true, pvp = true}
@@ -40,5 +40,13 @@ REGULAR_RESTRICTED_FUNCTIONS['reposition(e:v)']         = {build = true, pvp = t
 --REGULAR_RESTRICTED_FUNCTIONS['propBreak(e:)']         = {build = true, pvp = true}
 
 -- User rank restricted functions
-USER_RESTRICTED_FUNCTIONS = REGULAR_RESTRICTED_FUNCTIONS
+local USER_RESTRICTED_FUNCTIONS = REGULAR_RESTRICTED_FUNCTIONS
 ---------------------------------------------------------------------------------------
+
+local RESTRICTED_FUNCTIONS_BY_RANK = {
+    admin   = ADMIN_RESTRICTED_FUNCTIONS,
+    regular = REGULAR_RESTRICTED_FUNCTIONS,
+    user    = USER_RESTRICTED_FUNCTIONS
+}
+
+return RESTRICTED_FUNCTIONS, RESTRICTED_FUNCTIONS_BY_RANK

--- a/lua/autorun/server/sv_restricted_propcore_functions.lua
+++ b/lua/autorun/server/sv_restricted_propcore_functions.lua
@@ -15,19 +15,6 @@ local RESTRICTED_FUNCTIONS = {
   'propManipulate(e:vannn)',
   'reposition(e:v)'
 }
----------------------------------------------------------------------------------------
-
--- Get a copy of the provided table
-local function copyTableByValue(tab)
-    returnTable = {}
-
-    -- Copy by value
-    for key, value in pairs( tab ) do
-        returnTable[key] = value
-    end
-
-    return returnTable
-end
 
 -- Rank Restriction Tables
 ---------------------------------------------------------------------------------------
@@ -52,7 +39,7 @@ REGULAR_RESTRICTED_FUNCTIONS['reposition(e:v)']         = {build = true, pvp = t
 --REGULAR_RESTRICTED_FUNCTIONS['propBreak(e:)']         = {build = true, pvp = true}
 
 -- User rank restricted functions
-local USER_RESTRICTED_FUNCTIONS = copyTableByValue( REGULAR_RESTRICTED_FUNCTIONS )
+local USER_RESTRICTED_FUNCTIONS = table.Copy( REGULAR_RESTRICTED_FUNCTIONS )
 ---------------------------------------------------------------------------------------
 
 local RESTRICTED_FUNCTIONS_BY_RANK = {

--- a/lua/autorun/server/sv_restricted_propcore_functions.lua
+++ b/lua/autorun/server/sv_restricted_propcore_functions.lua
@@ -17,13 +17,25 @@ local RESTRICTED_FUNCTIONS = {
 }
 ---------------------------------------------------------------------------------------
 
+-- Get a copy of the provided table
+local function copyTableByValue(tab)
+    returnTable = {}
+
+    -- Copy by value
+    for key, value in pairs( tab ) do
+        returnTable[key] = value
+    end
+
+    return returnTable
+end
+
 -- Rank Restriction Tables
 ---------------------------------------------------------------------------------------
 -- Admin rank restricted functions
 local ADMIN_RESTRICTED_FUNCTIONS = {}
 
 -- Regular rank restricted functions
-local REGULAR_RESTRICTED_FUNCTIONS = ADMIN_RESTRICTED_FUNCTIONS
+local REGULAR_RESTRICTED_FUNCTIONS = copyTableByValue( ADMIN_RESTRICTED_FUNCTIONS )
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(sn)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(en)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(svn)']          = {build = true, pvp = true}
@@ -40,7 +52,7 @@ REGULAR_RESTRICTED_FUNCTIONS['reposition(e:v)']         = {build = true, pvp = t
 --REGULAR_RESTRICTED_FUNCTIONS['propBreak(e:)']         = {build = true, pvp = true}
 
 -- User rank restricted functions
-local USER_RESTRICTED_FUNCTIONS = REGULAR_RESTRICTED_FUNCTIONS
+local USER_RESTRICTED_FUNCTIONS = copyTableByValue( REGULAR_RESTRICTED_FUNCTIONS )
 ---------------------------------------------------------------------------------------
 
 local RESTRICTED_FUNCTIONS_BY_RANK = {

--- a/lua/autorun/server/sv_restricted_propcore_functions.lua
+++ b/lua/autorun/server/sv_restricted_propcore_functions.lua
@@ -1,0 +1,44 @@
+-- Restricted Propcore Functions
+---------------------------------------------------------------------------------------
+RESTRICTED_FUNCTIONS = {
+  'propSpawn(sn)',
+  'propSpawn(en)',
+  'propSpawn(svn)',
+  'propSpawn(evn)',
+  'propSpawn(san)',
+  'propSpawn(ean)',
+  'propSpawn(svan)',
+  'propSpawn(evan)',
+  'seatSpawn(sn)',
+  'seatSpawn(svan)',
+  'setPos(e:v)',
+  'propManipulate(e:vannn)',
+  'reposition(e:v)'
+}
+---------------------------------------------------------------------------------------
+
+-- Rank Restriction Tables
+---------------------------------------------------------------------------------------
+-- Admin rank restricted functions
+ADMIN_RESTRICTED_FUNCTIONS = {}
+
+-- Regular rank restricted functions
+REGULAR_RESTRICTED_FUNCTIONS = ADMIN_RESTRICTED_FUNCTIONS
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(sn)']           = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(en)']           = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(svn)']          = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(evn)']          = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(san)']          = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(ean)']          = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(svan)']         = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propSpawn(evan)']         = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['seatSpawn(sn)']           = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['seatSpawn(svan)']         = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['setPos(e:v)']             = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['propManipulate(e:vannn)'] = {build = true, pvp = true}
+REGULAR_RESTRICTED_FUNCTIONS['reposition(e:v)']         = {build = true, pvp = true}
+--REGULAR_RESTRICTED_FUNCTIONS['propBreak(e:)']         = {build = true, pvp = true}
+
+-- User rank restricted functions
+USER_RESTRICTED_FUNCTIONS = REGULAR_RESTRICTED_FUNCTIONS
+---------------------------------------------------------------------------------------

--- a/lua/autorun/server/sv_restricted_propcore_functions.lua
+++ b/lua/autorun/server/sv_restricted_propcore_functions.lua
@@ -22,7 +22,7 @@ local RESTRICTED_FUNCTIONS = {
 local ADMIN_RESTRICTED_FUNCTIONS = {}
 
 -- Regular rank restricted functions
-local REGULAR_RESTRICTED_FUNCTIONS = copyTableByValue( ADMIN_RESTRICTED_FUNCTIONS )
+local REGULAR_RESTRICTED_FUNCTIONS = table.Copy( ADMIN_RESTRICTED_FUNCTIONS )
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(sn)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(en)']           = {build = true, pvp = true}
 REGULAR_RESTRICTED_FUNCTIONS['propSpawn(svn)']          = {build = true, pvp = true}


### PR DESCRIPTION
Easiest to view `sv_restrict_propcore.lua` raw due to all of the deletions.

Like @brandonsturgeon said in #1, I understand that this will likely be scrapped, but I think we need to get this one in motion... So here's my first take. :)