### PR TITLE
register as e2 extension

### DIFF
--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -1,6 +1,6 @@
 -- Propcore is allowed to everyone, but functions in the restrictedFunctions array will be restricted to devotee+ only
 
-local function restrictPropCoreFunctions()
+function restrictPropCoreFunctions()
     local disallowedRanks = {}
     disallowedRanks["user"] = true
     disallowedRanks["regular"] = true
@@ -40,5 +40,3 @@ local function restrictPropCoreFunctions()
         end
     end
 end
-
-hook.Add( "OnGamemodeLoaded","propCoreRestrict", restrictPropCoreFunctions )

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_restrict_propcore_functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_restrict_propcore_functions.lua
@@ -1,0 +1,4 @@
+E2Lib.RegisterExtension( "cfc_propcore_restrictions", true, "Rank and pvp based restrictions for propcore")
+
+registerCallback("postinit", restrictPropCoreFunctions)
+


### PR DESCRIPTION
fixes propcore restrictions breaking when reloading and disabling/enabling e2 extensions