### PR TITLE
Restricting entity use

### DIFF
--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -4,7 +4,7 @@ function restrictPropCoreFunctions()
     local disallowedRanks = {}
     disallowedRanks["user"] = true
     disallowedRanks["regular"] = true
-    
+
     local restrictedFunctions = {
         "propSpawn(sn)",
         "propSpawn(en)",
@@ -21,11 +21,9 @@ function restrictPropCoreFunctions()
         "propManipulate(e:vannn)"
         --"propBreak(e:)"
     }
-    
     local adminOnlyFunctions = {
         "use(e:)"   
     }
-    
     for _, signature in pairs( restrictedFunctions ) do
         if wire_expression2_funcs then
             local oldFunc = wire_expression2_funcs[signature][3]
@@ -34,7 +32,7 @@ function restrictPropCoreFunctions()
                 if ( disallowedRanks[self.player:GetUserGroup()] == nil ) then
                     local isInBuildMode = self.player:GetNWBool("CFC_PvP_Mode", false) == false
 
-                    if( isInBuildMode or self.player:IsAdmin() ) then
+                    if isInBuildMode or self.player:IsAdmin() then
                         return oldFunc( self, ... )
                     else
                         self.player:ChatPrint( "You can't use PropCore in PvP mode" )
@@ -49,7 +47,6 @@ function restrictPropCoreFunctions()
     for _, signature in pairs( adminOnlyFunctions ) do
         if wire_expression2_funcs then
             local oldFunc = wire_expression2_funcs[signature][3]
-
                wire_expression2_funcs[signature][3] = function( self, ... )
                if ( self.player:IsAdmin() ) then
                     return oldFunc( self, ... )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -27,10 +27,12 @@ function restrictPropCoreFunctions()
     }
 
     restrict( restrictedFunctions, function( self,  ... )
+        local isInPvP = self.player:GetNWBool( "CFC_Pvp_Mode" )
+
         if disallowedRanks[self.player:GetUserGroup()] then
             return false, "You don't have access to this function"
-        elseif self.player:GetNWBool( "CFC_PvP_Mode" ) == true then
-            return false, "You can't use propcore in PvP"
+        elseif isInPvP == true then
+             return false, "You can't use propcore in PvP"
         else
             return true
         end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -21,39 +21,40 @@ function restrictPropCoreFunctions()
         "propManipulate(e:vannn)"
         --"propBreak(e:)"
     }
+
     local adminOnlyFunctions = {
         "use(e:)"
     }
+
     for _, signature in pairs( restrictedFunctions ) do
-        if wire_expression2_funcs then
-            local oldFunc = wire_expression2_funcs[signature][3]
+        local oldFunc = wire_expression2_funcs[signature][3]
 
-            wire_expression2_funcs[signature][3] = function( self, ... )
-                if disallowedRanks[self.player:GetUserGroup()] == nil then
-                    local isInBuildMode = self.player:GetNWBool("CFC_PvP_Mode", false) == false
+        wire_expression2_funcs[signature][3] = function( self, ... )
+            if disallowedRanks[self.player:GetUserGroup()] == nil then
+                local isInBuildMode = self.player:GetNWBool("CFC_PvP_Mode", false) == false
 
-                    if isInBuildMode or self.player:IsAdmin() then
-                        return oldFunc( self, ... )
-                    else
-                        self.player:ChatPrint( "You can't use PropCore in PvP mode" )
-                    end
+                if isInBuildMode or self.player:IsAdmin() then
+                    return oldFunc( self, ... )
                 else
-                    self.player:ChatPrint( "You don't have access to " .. signature )
+                    self.player:ChatPrint( "You can't use PropCore in PvP mode" )
                 end
+            else
+                self.player:ChatPrint( "You don't have access to " .. signature )
             end
+        end
+    end
 
-
-            wire_expression2_funcs[signature][3] = function( self, ... )
-                if not self.player:IsAdmin() then self.player:ChatPrint( "You don't have access to" .. signature )
-                if not self.player:IsAdmin() then return end
-
-                local oldFunc = wire_expression2_funcs[signature][3]
-
+    for _, signature in pairs( adminOnlyFunctions ) do 
+        local oldFunc = wire_expression2_funcs[signature][3]
+           wire_expression2_funcs[signature][3] = function( self, ... )
+           if ( self.player:IsAdmin() ) then
                 return oldFunc( self, ... )
-            end
+           else
+                self.player:ChatPrint( "You don't have access to " .. signature )
+           end
         end
     end
 end
 
+
 hook.Add( "OnGamemodeLoaded","propCoreRestrict", restrictPropCoreFunctions )
-end -- I don't know why this needs to be here.

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -53,18 +53,18 @@ end
 		return true
 end
 
-	local function restrict( signatures, condition )
-    	for _, signature in pairs( signatures ) do
-        	local oldFunc = wire_expression2_funcs[signature][3]
+local function restrict( signatures, condition )
+	for _, signature in pairs( signatures ) do
+    	local oldFunc = wire_expression2_funcs[signature][3]
 
-        	wire_expression2_funcs[signature][3] = function( self, ... )
-            	canRun, reason = condition( self, ... )
+    	wire_expression2_funcs[signature][3] = function( self, ... )
+        	canRun, reason = condition( self, ... )
 
-	            if canRun then
-    	            return oldFunc( self, ... )
-        	    else
-            	    self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
-            	end
+            if canRun then
+	            return oldFunc( self, ... )
+    	    else
+        	    self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
         	end
     	end
 	end
+end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -100,9 +100,9 @@ local function restrict( signatures, condition )
             if not canRun then
                 return s.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
             end
-        end
 
-        return oldFunc( self, ... )
+            return oldFunc( self, ... )
+        end
     end
 end
 

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -51,7 +51,7 @@ local function restrict( signatures, condition )
         local oldFunc = wire_expression2_funcs[signature][3]
 
         wire_expression2_funcs[signature][3] = function( self, ... )
-            canRun, reason = condition( self, ... )
+            local canRun, reason = condition( self, ... )
 
             if canRun then
                 return oldFunc( self, ... )
@@ -66,4 +66,3 @@ function restrictPropCoreFunctions()
     restrict( restrictedFunctions, restrictedCondition )
     restrict( adminOnlyFunctions, adminOnlyCondition )
 end
-

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -56,3 +56,4 @@ function restrictPropCoreFunctions()
 end
 
 hook.Add( "OnGamemodeLoaded","propCoreRestrict", restrictPropCoreFunctions )
+end -- I don't know why this needs to be here.

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -41,7 +41,7 @@ local function restrictedCondition( self, ... )
     end
 
     if isInBuildMode and not self.player:IsAdmin() then
-        return false, "you can't use propcore in PvP"
+        return false, "You can't use propcore in PvP"
     end
     return true
 end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -41,7 +41,7 @@ local function restrictedCondition( self, ... )
 
 
     if not isInBuildMode and not self.player:IsAdmin() then
-        return false, "you can't use propcore in PvP"
+        return false, "You can't use propcore in PvP"
     end
 
     return true

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -60,7 +60,7 @@ function restrict( signatures, condition )
             if canRun then
                 return oldFunc( self, ... )
             else
-                self.player:ChatPrint( "Couldn't run ".. signature .. ":" .. reason )
+                self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -4,7 +4,7 @@ function restrictPropCoreFunctions()
     local disallowedRanks = {}
     disallowedRanks["user"] = true
     disallowedRanks["regular"] = true
-
+    
     local restrictedFunctions = {
         "propSpawn(sn)",
         "propSpawn(en)",
@@ -16,12 +16,16 @@ function restrictPropCoreFunctions()
         "propSpawn(evan)",
         "seatSpawn(sn)",
         "seatSpawn(svan)",
-        "setPos(e:v)", -- Test
+        "setPos(e:v)",
         "reposition(e:v)",
         "propManipulate(e:vannn)"
         --"propBreak(e:)"
     }
-
+    
+    local adminOnlyFunctions = {
+        "use(e:)"   
+    }
+    
     for _, signature in pairs( restrictedFunctions ) do
         if wire_expression2_funcs then
             local oldFunc = wire_expression2_funcs[signature][3]
@@ -38,6 +42,20 @@ function restrictPropCoreFunctions()
                 else
                     self.player:ChatPrint( "You don't have access to " .. signature )
                 end
+            end
+        end
+    end
+    
+    for _, signature in pairs( adminOnlyFunctions ) do
+        if wire_expression2_funcs then
+            local oldFunc = wire_expression2_funcs[signature][3]
+
+               wire_expression2_funcs[signature][3] = function( self, ... )
+               if ( self.player:IsAdmin() ) then
+                    return oldFunc( self, ... )
+               else
+                    self.player:ChatPrint( "You don't have access to " .. signature )
+               end
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -57,7 +57,7 @@ function restrict( signatures, condition )
             if canRun then
                 return oldFunc( self, ... )
             else
-                self.player:ChatPrint( err )                
+                self.player:ChatPrint( err )               
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -45,7 +45,7 @@ function restrictPropCoreFunctions()
         else
             return false, "Only Admins can use this function"
         end
-    end)
+    end )
 end
 
 
@@ -65,4 +65,3 @@ function restrict( signatures, condition )
         end
     end
 end
-

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -44,7 +44,7 @@ function restrictPropCoreFunctions()
         end
     end
 
-    for _, signature in pairs( adminOnlyFunctions ) do 
+    for _, signature in pairs( adminOnlyFunctions ) do
         local oldFunc = wire_expression2_funcs[signature][3]
            wire_expression2_funcs[signature][3] = function( self, ... )
            if ( self.player:IsAdmin() ) then

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -1,7 +1,31 @@
 -- Propcore is allowed to everyone, but functions in the restrictedFunctions array will be restricted to devotee+ only
 
+local disallowedRanks = {}
+disallowedRanks["user"] = true
+disallowedRanks["regular"] = true
 
-local function adminOnlyCondition( self, ... ) 
+local restrictedFunctions = {
+    "propSpawn(sn)",
+    "propSpawn(en)",
+    "propSpawn(svn)",
+    "propSpawn(evn)",
+    "propSpawn(san)",
+    "propSpawn(ean)",
+    "propSpawn(svan)",
+    "propSpawn(evan)",
+    "seatSpawn(sn)",
+    "seatSpawn(svan)",
+    "setPos(e:v)",
+    "reposition(e:v)",
+    "propManipulate(e:vannn)"
+    --"propBreak(e:)"
+}
+
+local adminOnlyFunctions = {
+    "use(e:)"
+}
+
+local function adminOnlyCondition( self, ... )
     if self.player:IsAdmin() then
         return true
     end
@@ -9,7 +33,7 @@ local function adminOnlyCondition( self, ... )
     return false, "Only Admins can use this function"
 end
 
-local function restrictedCondition( self, ... ) 
+local function restrictedCondition( self, ... )
     local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
 
     if disallowedRanks[self.player:GetUserGroup()] then
@@ -39,31 +63,6 @@ local function restrict( signatures, condition )
 end
 
 function restrictPropCoreFunctions()
-    local disallowedRanks = {}
-    disallowedRanks["user"] = true
-    disallowedRanks["regular"] = true
-
-    local restrictedFunctions = {
-        "propSpawn(sn)",
-        "propSpawn(en)",
-        "propSpawn(svn)",
-        "propSpawn(evn)",
-        "propSpawn(san)",
-        "propSpawn(ean)",
-        "propSpawn(svan)",
-        "propSpawn(evan)",
-        "seatSpawn(sn)",
-        "seatSpawn(svan)",
-        "setPos(e:v)",
-        "reposition(e:v)",
-        "propManipulate(e:vannn)"
-        --"propBreak(e:)"
-    }
-
-
-    local adminOnlyFunctions = {
-        "use(e:)"
-    }
 
     restrict( restrictedFunctions, restrictedCondition )
     restrict( adminOnlyFunctions, adminOnlyCondition )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -34,15 +34,10 @@ end
 local function checkForPvP( player )
     local isInBuildMode = player:GetNWBool( "CFC_PvP_Mode" )
 
-    if not isInBuildMode and not self.player:IsAdmin() then
+    if not isInBuildMode and not player:IsAdmin() then
         return false, "You can't use propcore in PvP"
 
     end
-end
-
-local function playerCanRun( self, ... )
-    isAllowedRank( disallowedRanks, self.player )
-    checkForPvP( self.player )
 end
 
 local function restrict( signatures, condition )
@@ -50,10 +45,10 @@ local function restrict( signatures, condition )
         local oldFunc = wire_expression2_funcs[signature][3]
 
         wire_expression2_funcs[signature][3] = function( self, ... )
-            local canRun, reason = condition( self, ... )
+            local canRun, reason = condition( s, ... )
 
             if not canRun then
-                return self.player:ChatPrint( "Couldn't run ".. signature .. ":" .. reason )
+                return s.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
             end
 
             return oldFunc( self, ... )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -22,7 +22,7 @@ function restrictPropCoreFunctions()
         --"propBreak(e:)"
     }
     local adminOnlyFunctions = {
-        "use(e:)"   
+        "use(e:)"
     }
     for _, signature in pairs( restrictedFunctions ) do
         if wire_expression2_funcs then
@@ -43,7 +43,7 @@ function restrictPropCoreFunctions()
             end
         end
     end
-    
+
     for _, signature in pairs( adminOnlyFunctions ) do
         if wire_expression2_funcs then
             local oldFunc = wire_expression2_funcs[signature][3]

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -37,7 +37,7 @@ function restrictPropCoreFunctions()
         else
             return true
         end
-    end)
+    end )
 
     restrict( adminOnlyFunctions, function( self, ...)
         if self.player:IsAdmin() then

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -25,15 +25,6 @@ local adminOnlyFunctions = {
     "use(e:)"
 }
 
-local function checkForPvP( player )
-    local isInBuildMode = player:GetNWBool( "CFC_PvP_Mode" )
-
-    if not isInBuildMode and not player:IsAdmin() then
-        return false, "You can't use propcore in PvP"
-
-    end
-end
-
 local function restrict( signatures, condition )
     for _, signature in pairs( signatures ) do
         local oldFunc = wire_expression2_funcs[signature][3]

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -27,30 +27,33 @@ function restrictPropCoreFunctions()
         "use(e:)"
     }
 
-    restrict( restrictedFunctions, function( self,  ... )
-        local isInBuildMode = self.player:GetNWBool( "CFC_Pvp_Mode" ) == false
-
-        if disallowedRanks[self.player:GetUserGroup()] then
-            return false, "You don't have access to this function"
-        elseif isInBuildMode and not self.player:IsAdmin() then
-             return false, "You can't use propcore in PvP"
-        else
-            return true
-        end
-    end)
-
-    restrict( adminOnlyFunctions, function( self, ...)
-        if self.player:IsAdmin() then
-            return true
-        else
-            return false, "Only Admins can use this function"
-        end
-    end )
+    restrict( restrictedFunctions, restrictedCondition( self, ... ) )
+    restrict( adminOnlyFunctions, adminOnlyCondition( self, ... ) )
 end
 
+local function adminOnlyCondition( self, ... ) 
+	if self.player:IsAdmin() then
+		return true
+	end
 
+	return false, "Only Admins can use this function"
+end
 
-function restrict( signatures, condition )
+local function restrictedCondition( self, ... ) 
+	local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
+
+	if disallowedRanks[self.player:GetUserGroup()] then
+		return false, "You don't have access to this function"
+	end
+
+	if isInBuildMode and not self.player:IsAdmin() then
+		return false, "you can't use propcore in PvP"
+	end
+
+	return true
+end
+
+local function restrict( signatures, condition )
     for _, signature in pairs( signatures ) do
         local oldFunc = wire_expression2_funcs[signature][3]
 

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -56,5 +56,4 @@ function restrictPropCoreFunctions()
     end
 end
 
-
 hook.Add( "OnGamemodeLoaded","propCoreRestrict", restrictPropCoreFunctions )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -57,7 +57,7 @@ function restrict( signatures, condition )
             if canRun then
                 return oldFunc( self, ... )
             else
-                self.player:ChatPrint( err )             
+                self.player:ChatPrint( err )
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -32,26 +32,25 @@ function restrictPropCoreFunctions()
 end
 
 
-local function adminOnlyCondition( self, ... ) 
-	if self.player:IsAdmin() then
+	local function adminOnlyCondition( self, ... ) 
+		if self.player:IsAdmin() then
+			return true
+		end
+
+		return false, "Only Admins can use this function"
+	end
+
+	local function restrictedCondition( self, ... ) 
+		local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
+
+		if disallowedRanks[self.player:GetUserGroup()] then
+			return false, "You don't have access to this function"
+		end
+
+		if isInBuildMode and not self.player:IsAdmin() then
+			return false, "you can't use propcore in PvP"
+		end
 		return true
-	end
-
-	return false, "Only Admins can use this function"
-end
-
-local function restrictedCondition( self, ... ) 
-	local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
-
-	if disallowedRanks[self.player:GetUserGroup()] then
-		return false, "You don't have access to this function"
-	end
-
-	if isInBuildMode and not self.player:IsAdmin() then
-		return false, "you can't use propcore in PvP"
-	end
-
-	return true
 end
 
 local function restrict( signatures, condition )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -32,25 +32,25 @@ function restrictPropCoreFunctions()
 end
 
 
-	local function adminOnlyCondition( self, ... ) 
-		if self.player:IsAdmin() then
-			return true
-		end
-
-		return false, "Only Admins can use this function"
+local function adminOnlyCondition( self, ... ) 
+	if self.player:IsAdmin() then
+		return true
 	end
 
-	local function restrictedCondition( self, ... ) 
-		local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
+	return false, "Only Admins can use this function"
+end
 
-		if disallowedRanks[self.player:GetUserGroup()] then
-			return false, "You don't have access to this function"
-		end
+local function restrictedCondition( self, ... ) 
+	local isInBuildMode = self.player:GetNWBool( "CFC_PvP_Mode" ) == false
 
-		if isInBuildMode and not self.player:IsAdmin() then
-			return false, "you can't use propcore in PvP"
-		end
-		return true
+	if disallowedRanks[self.player:GetUserGroup()] then
+		return false, "You don't have access to this function"
+	end
+
+	if isInBuildMode and not self.player:IsAdmin() then
+		return false, "you can't use propcore in PvP"
+	end
+	return true
 end
 
 local function restrict( signatures, condition )

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -43,7 +43,7 @@ local function restrictedCondition( self, ... )
     if not isInBuildMode and not self.player:IsAdmin() then
         return false, "you can't use propcore in PvP"
     end
-    
+
     return true
 end
 

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -39,7 +39,6 @@ local function restrictedCondition( self, ... )
         return false, "You don't have access to this function"
     end
 
-
     if not isInBuildMode and not self.player:IsAdmin() then
         return false, "You can't use propcore in PvP"
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -57,7 +57,7 @@ function restrict( signatures, condition )
             if canRun then
                 return oldFunc( self, ... )
             else
-                self.player:ChatPrint( err )               
+                self.player:ChatPrint( err )             
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -58,13 +58,13 @@ end
         	local oldFunc = wire_expression2_funcs[signature][3]
 
         	wire_expression2_funcs[signature][3] = function( self, ... )
-            canRun, reason = condition( self, ... )
+            	canRun, reason = condition( self, ... )
 
-            if canRun then
-                return oldFunc( self, ... )
-            else
-                self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
-            end
-        end
-    end
-end
+	            if canRun then
+    	            return oldFunc( self, ... )
+        	    else
+            	    self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
+            	end
+        	end
+    	end
+	end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -28,11 +28,11 @@ function restrictPropCoreFunctions()
     }
 
     restrict( restrictedFunctions, function( self,  ... )
-        local isInPvP = self.player:GetNWBool( "CFC_Pvp_Mode" )
+        local isInBuildMode = self.player:GetNWBool( "CFC_Pvp_Mode" ) == false
 
         if disallowedRanks[self.player:GetUserGroup()] then
             return false, "You don't have access to this function"
-        elseif isInPvP == true then
+        elseif isInBuildMode and not self.player:IsAdmin() then
              return false, "You can't use propcore in PvP"
         else
             return true
@@ -55,12 +55,12 @@ function restrict( signatures, condition )
         local oldFunc = wire_expression2_funcs[signature][3]
 
         wire_expression2_funcs[signature][3] = function( self, ... )
-            canRun, err = condition( self, ... )
+            canRun, reason = condition( self, ... )
 
             if canRun then
                 return oldFunc( self, ... )
             else
-                self.player:ChatPrint( err )
+                self.player:ChatPrint( "Couldn't run ".. signature .. ":" .. reason )
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -25,12 +25,6 @@ local adminOnlyFunctions = {
     "use(e:)"
 }
 
-local function isAllowedRank( ranks, player )
-    if ranks[player:GetUserGroup()] then
-        return false, "You don't have access to this function"
-    end
-end
-
 local function checkForPvP( player )
     local isInBuildMode = player:GetNWBool( "CFC_PvP_Mode" )
 

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -53,18 +53,18 @@ end
 		return true
 end
 
-local function restrict( signatures, condition )
-    for _, signature in pairs( signatures ) do
-        local oldFunc = wire_expression2_funcs[signature][3]
+	local function restrict( signatures, condition )
+    	for _, signature in pairs( signatures ) do
+        	local oldFunc = wire_expression2_funcs[signature][3]
 
-        wire_expression2_funcs[signature][3] = function( self, ... )
-            canRun, reason = condition( self, ... )
+        	wire_expression2_funcs[signature][3] = function( self, ... )
+            	canRun, reason = condition( self, ... )
 
-            if canRun then
-                return oldFunc( self, ... )
-            else
-                self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
-            end
-        end
-    end
-end
+            	if canRun then
+                	return oldFunc( self, ... )
+            	else
+                	self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
+            	end
+        	end
+    	end
+	end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -63,9 +63,7 @@ local function restrict( signatures, condition )
 end
 
 function restrictPropCoreFunctions()
-
     restrict( restrictedFunctions, restrictedCondition )
     restrict( adminOnlyFunctions, adminOnlyCondition )
 end
-
 

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -24,7 +24,6 @@ local restrictedFunctions = {
 local adminOnlyFunctions = {
     "use(e:)"
 }
-
 local function adminOnlyCondition( self, ... )
     if self.player:IsAdmin() then
         return true
@@ -40,7 +39,7 @@ local function restrictedCondition( self, ... )
         return false, "You don't have access to this function"
     end
 
-    if isInBuildMode and not self.player:IsAdmin() then
+    if not isInBuildMode and not self.player:IsAdmin() then
         return false, "you can't use propcore in PvP"
     end
     return true

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -16,7 +16,7 @@ function restrictPropCoreFunctions()
         "propSpawn(evan)",
         "seatSpawn(sn)",
         "seatSpawn(svan)",
-        "setPos(e:v)",
+        "setPos(e:v)", -- Test
         "reposition(e:v)",
         "propManipulate(e:vannn)"
         --"propBreak(e:)"

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -29,7 +29,7 @@ function restrictPropCoreFunctions()
             local oldFunc = wire_expression2_funcs[signature][3]
 
             wire_expression2_funcs[signature][3] = function( self, ... )
-                if ( disallowedRanks[self.player:GetUserGroup()] == nil ) then
+                if disallowedRanks[self.player:GetUserGroup()] == nil then
                     local isInBuildMode = self.player:GetNWBool("CFC_PvP_Mode", false) == false
 
                     if isInBuildMode or self.player:IsAdmin() then
@@ -41,18 +41,15 @@ function restrictPropCoreFunctions()
                     self.player:ChatPrint( "You don't have access to " .. signature )
                 end
             end
-        end
-    end
 
-    for _, signature in pairs( adminOnlyFunctions ) do
-        if wire_expression2_funcs then
-            local oldFunc = wire_expression2_funcs[signature][3]
-               wire_expression2_funcs[signature][3] = function( self, ... )
-               if ( self.player:IsAdmin() ) then
-                    return oldFunc( self, ... )
-               else
-                    self.player:ChatPrint( "You don't have access to " .. signature )
-               end
+
+            wire_expression2_funcs[signature][3] = function( self, ... )
+                if not self.player:IsAdmin() then self.player:ChatPrint( "You don't have access to" .. signature )
+                if not self.player:IsAdmin() then return end
+
+                local oldFunc = wire_expression2_funcs[signature][3]
+
+                return oldFunc( self, ... )
             end
         end
     end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -27,8 +27,8 @@ function restrictPropCoreFunctions()
         "use(e:)"
     }
 
-    restrict( restrictedFunctions, restrictedCondition( self, ... ) )
-    restrict( adminOnlyFunctions, adminOnlyCondition( self, ... ) )
+    restrict( restrictedFunctions, restrictedCondition )
+    restrict( adminOnlyFunctions, adminOnlyCondition )
 end
 
 
@@ -36,14 +36,6 @@ local function adminOnlyCondition( self, ... )
 	if self.player:IsAdmin() then
 		return true
 	end
-
-        if disallowedRanks[self.player:GetUserGroup()] then
-            return false, "You don't have access to this function"
-        elseif isInBuildMode and not self.player:IsAdmin() then
-             return false, "You can't use propcore in PvP"
-        else
-            return true
-        end
 
 	return false, "Only Admins can use this function"
 end

--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -58,13 +58,13 @@ end
         	local oldFunc = wire_expression2_funcs[signature][3]
 
         	wire_expression2_funcs[signature][3] = function( self, ... )
-            	canRun, reason = condition( self, ... )
+            canRun, reason = condition( self, ... )
 
-            	if canRun then
-                	return oldFunc( self, ... )
-            	else
-                	self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
-            	end
-        	end
-    	end
-	end
+            if canRun then
+                return oldFunc( self, ... )
+            else
+                self.player:ChatPrint( "Couldn't run " .. signature .. ":" .. reason )
+            end
+        end
+    end
+end


### PR DESCRIPTION
Restricting `entity:use()` to Admin+