### PR TITLE
Support CFC PvP 2.0

### DIFF
--- a/lua/autorun/server/sv_restrict_propcore.lua
+++ b/lua/autorun/server/sv_restrict_propcore.lua
@@ -45,10 +45,6 @@ local function isCorrectRank( ply )
     return not disallowedRanks[ply:GetUserGroup()]
 end
 
-local function isInPvp( ply )
-    return ply:GetNWBool("CFC_PvP_Mode", false)
-end
-
 -- Conditions
 local function adminOnlyCondition( self, ... )
     if self.player:IsAdmin() then
@@ -59,9 +55,10 @@ local function adminOnlyCondition( self, ... )
 end
 
 local function restrictedCondition( self, ... )
-    if self.player:IsAdmin() then return true end
+    local canUse, message = hook.Run( "CFC_RestrictPropCore_CanUse", self.player, self )
+    if canUse ~= nil then return canUse, message end
 
-    if isInPvp( self.player ) then return false, "Cannot be used in PvP mode" end
+    if self.player:IsAdmin() then return true end
 
     if CFCPropcoreRestrict.playerIsWhitelisted( self.player ) then return true end
     if not isCorrectRank( self.player ) then return false, "Incorrect Rank" end

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_restrict_propcore_functions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_restrict_propcore_functions.lua
@@ -1,4 +1,4 @@
-E2Lib.RegisterExtension( "cfc_propcore_restrictions", true, "Rank and pvp based restrictions for propcore")
+E2Lib.RegisterExtension( "cfc_propcore_restrictions", true, "Rank based restrictions for propcore")
 
 registerCallback("postinit", restrictPropCoreFunctions)
 


### PR DESCRIPTION
Pulls explicit PvP checks out of the addon so a new plugin can be made in CFC Pvp